### PR TITLE
Fix volume control for stereo fader

### DIFF
--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -103,7 +103,7 @@ then
     if [ ! -f $VOLFILE ]; then
         # $VOLFILE does NOT exist == audio on
         # read volume in percent and write to $VOLFILE
-        amixer sget \'$DEVICE\' | grep -Po '(?<=\[)[^]]*(?=%])' > $VOLFILE
+        amixer sget \'$DEVICE\' | grep -Po -m 1 '(?<=\[)[^]]*(?=%])' > $VOLFILE
         # set volume to 0%
         amixer sset \'$DEVICE\' 0%
     else
@@ -124,7 +124,7 @@ then
     if [ ! -f $VOLFILE ]; then
         # $VOLFILE does NOT exist == audio on
         # read volume in percent
-        VOLPERCENT=`amixer sget \'$DEVICE\' | grep -Po '(?<=\[)[^]]*(?=%])'`
+        VOLPERCENT=`amixer sget \'$DEVICE\' | grep -Po -m 1 '(?<=\[)[^]]*(?=%])'`
         echo $VOLPERCENT
         # increase by $VOLSTEP
         VOLPERCENT=`expr ${VOLPERCENT} + ${VOLSTEP}` 
@@ -145,7 +145,7 @@ elif [ "$COMMAND" == "volumedown" ]
     if [ ! -f $VOLFILE ]; then
         # $VOLFILE does NOT exist == audio on
         # read volume in percent
-        VOLPERCENT=`amixer sget \'$DEVICE\' | grep -Po '(?<=\[)[^]]*(?=%])'`
+        VOLPERCENT=`amixer sget \'$DEVICE\' | grep -Po -m 1 '(?<=\[)[^]]*(?=%])'`
         echo $VOLPERCENT
         # increase by $VOLSTEP
         VOLPERCENT=`expr ${VOLPERCENT} - ${VOLSTEP}` 


### PR DESCRIPTION
Adding -m 1 to the grep line for getting proper values for the volume for stereo faders. The -m 1 is not really needed in the "mute" section as it works somehow without it, but added for cleanliness.